### PR TITLE
Converting into a module so it can be called externally.

### DIFF
--- a/solid/utils.py
+++ b/solid/utils.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import os, sys, re
 
-from solid import *
+from . import *
 from math import *
 
 RIGHT, TOP, LEFT, BOTTOM = range(4)


### PR DESCRIPTION
The tool was originally written as a CLI.
You should now be able to import BoardBuilder from another module and run it via another python script.